### PR TITLE
Change the API to improve readability

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,39 +1,85 @@
-package errors
+package friendly
 
 import (
 	"errors"
 )
 
-var DefaultUserError = errors.New("Something went wrong.")
+var DefaultUserError = errors.New("Something went wrong")
 
 type Error struct {
-	error     error
-	userError error
+	cause    error
+	friendly error
+}
+
+func New() Error {
+	return Error{
+		cause:    DefaultUserError,
+		friendly: DefaultUserError,
+	}
+}
+
+// WithCause sets the internal non-user-safe cause of the error.
+func (e Error) WithCause(err error) Error {
+	e.cause = err
+	return e
+}
+
+// WithFriendly sets the user-safe cause of the error.
+func (e Error) WithFriendly(err error) Error {
+	e.friendly = err
+	return e
+}
+
+// WithCauseString sets the internal non-user-safe cause of the error.
+func (e Error) WithCauseString(err string) Error {
+	e.cause = errors.New(err)
+	return e
+}
+
+// WithFriendlyString sets the user-safe cause of the error.
+func (e Error) WithFriendlyString(err string) Error {
+	e.friendly = errors.New(err)
+	return e
+}
+
+// Err returns the friendly error as an 'error', if an underlying cause is
+// present.
+func (e Error) Err() error {
+	if e.cause == nil {
+		return nil
+	}
+	return e
+}
+
+// Cause returns the underlying cause error.
+func (e Error) Cause() error {
+	return e.cause
+}
+
+// Friendly returns the underlying friendly error.
+func (e Error) Friendly() error {
+	return e.friendly
 }
 
 func (e Error) Error() string {
-	return e.error.Error()
+	return e.cause.Error()
 }
 
-func (e Error) UserError() error {
-	return e.userError
-}
-
-// Cause takes any error and will return the first user-friendly error it finds
+// Friendly takes any error and will return the first user-friendly error it finds
 // as it traverses up through the linked list. If there are no user-friendly
 // causes found, nil is returned.
-func User(err error) error {
+func Friendly(err error) error {
 	type errCauser interface {
 		Cause() error
 	}
-	type errUser interface {
-		UserError() error
+	type errFriendlyer interface {
+		Friendly() error
 	}
 
 	for err != nil {
-		user, ok := err.(errUser)
+		user, ok := err.(errFriendlyer)
 		if ok {
-			return user.UserError()
+			return user.Friendly()
 		}
 
 		cause, ok := err.(errCauser)
@@ -44,30 +90,4 @@ func User(err error) error {
 	}
 
 	return nil
-}
-
-func NewError(err, user error) error {
-	if err == nil {
-		return nil
-	}
-
-	if user == nil {
-		user = DefaultUserError
-	}
-
-	return &Error{
-		error:     err,
-		userError: user,
-	}
-}
-
-func NewErrorString(err, user string) error {
-	if err == "" {
-		return nil
-	}
-
-	return &Error{
-		error:     errors.New(err),
-		userError: errors.New(user),
-	}
 }

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package friendly
 
 import (
 	"errors"
+	"fmt"
 )
 
 var DefaultUserError = errors.New("Something went wrong")
@@ -90,4 +91,16 @@ func Friendly(err error) error {
 	}
 
 	return nil
+}
+
+// Wrap is a convience method to easily add a friendly message for an existing
+// error.
+func Wrap(cause error, friendly string) error {
+	return New().WithCause(cause).WithFriendlyString(friendly).Err()
+}
+
+// Wrapf is a convience method to easily add a friendly message for an existing
+// error.
+func Wrapf(cause error, friendly string, a ...interface{}) error {
+	return New().WithCause(cause).WithFriendlyString(fmt.Sprintf(friendly, a...)).Err()
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,26 +1,26 @@
-package errors_test
+package friendly_test
 
 import (
 	"log"
 	"testing"
 
-	. "github.com/dylannz-sailthru/errors"
+	. "github.com/dylannz-sailthru/go-friendly"
 	"github.com/pkg/errors"
 )
 
 var (
-	ErrSecret = errors.New("something secret went wrong")
-	ErrUser   = errors.New("something public went wrong")
+	ErrCause    = errors.New("something secret went wrong")
+	ErrFriendly = errors.New("something public went wrong")
 )
 
 func someErr() error {
-	return ErrSecret
+	return ErrCause
 }
 
 func implementation() error {
 	err := someErr()
 	if err != nil {
-		return NewError(err, ErrUser)
+		return New().WithCause(err).WithFriendly(ErrFriendly)
 	}
 
 	return nil
@@ -29,29 +29,29 @@ func implementation() error {
 func TestConstructor(t *testing.T) {
 	err := implementation()
 
-	e, ok := err.(*Error)
+	e, ok := err.(Error)
 	if !ok {
 		log.Fatalf("expected err to be of type *Error, was: %T", err)
 	}
-	if e.UserError() != ErrUser {
-		log.Fatalf("expected user error to be: %v, got: %v", ErrUser.Error(), e.UserError())
+	if e.Friendly() != ErrFriendly {
+		log.Fatalf("expected user error to be: %v, got: %v", ErrFriendly.Error(), e.Friendly())
 	}
 
-	if err.Error() != ErrSecret.Error() {
-		log.Fatalf("expected cause to be: %v, got: %v", ErrSecret.Error(), err.Error())
+	if err.Error() != ErrCause.Error() {
+		log.Fatalf("expected cause to be: %v, got: %v", ErrCause.Error(), err.Error())
 	}
 }
 
 func TestUserCauseWithThirdPartyError(t *testing.T) {
 	c := errors.New("generic error")
-	err := NewError(c, nil)
+	err := New().WithCause(c).Err()
 
-	e, ok := err.(*Error)
+	e, ok := err.(Error)
 	if !ok {
 		log.Fatalf("expected err to be of type *Error, was: %T", err)
 	}
-	if e.UserError() != DefaultUserError {
-		log.Fatalf("expected user error to be: %v, got: %v", DefaultUserError, e.UserError())
+	if e.Friendly() != DefaultUserError {
+		log.Fatalf("expected user error to be: %v, got: %v", DefaultUserError, e.Friendly())
 	}
 
 	if err.Error() != c.Error() {
@@ -59,23 +59,26 @@ func TestUserCauseWithThirdPartyError(t *testing.T) {
 	}
 }
 
-func TestConstructorWithNilUserError(t *testing.T) {
-	err := NewError(nil, nil)
+func TestConstructorWithNilCauseAndNilFriendly(t *testing.T) {
+	err := New().WithCause(nil).WithFriendly(nil).Err()
 	if err != nil {
 		log.Fatalf("expected err to be nil, got: %v", err)
 	}
-	err = NewError(nil, errors.New("some error"))
+}
+
+func TestConstructorWithNilCause(t *testing.T) {
+	err := New().WithCause(nil).WithFriendly(errors.New("some error")).Err()
 	if err != nil {
 		log.Fatalf("expected err to be nil, got: %v", err)
 	}
 }
 
 func TestUser(t *testing.T) {
-	err := NewError(ErrSecret, ErrUser)
+	err := New().WithCause(ErrCause).WithFriendly(ErrFriendly).Err()
 	wrapped := errors.Wrap(err, "some wrapper")
 
-	if ErrUser != User(wrapped) {
-		log.Fatalf("expected unwrapped user error (%v) to equal original user err (%v)", User(wrapped), ErrUser)
+	if ErrFriendly != Friendly(wrapped) {
+		log.Fatalf("expected unwrapped user error (%v) to equal original user err (%v)", Friendly(wrapped), ErrFriendly)
 	}
 }
 
@@ -83,7 +86,7 @@ func TestUserWithNonUserError(t *testing.T) {
 	err := errors.New("some non-user error")
 	wrapped := errors.Wrap(err, "some wrapper")
 
-	if User(wrapped) != nil {
-		log.Fatalf("expected unwrapped user error (%v) to be nil", User(wrapped))
+	if Friendly(wrapped) != nil {
+		log.Fatalf("expected unwrapped user error (%v) to be nil", Friendly(wrapped))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/dylannz-sailthru/go-friendly
+
+go 1.13
+
+require github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Instead of:

```
import "github.com/dylannz-sailthru/errors"
...
errors.New("cause", "user error")
```

We now use:
```
import friendly "github.com/dylannz-sailthru/go-friendly"
...
friendly.New().WithCause(err).WithFriendlyString("user error").Err()
```

Also adding:

```
friendly.Wrap(err, "some friendly text")
friendly.Wrapf(err, "some friendly text: %s", something)
```

These are probably going to be the most common usage of this package I would think ^